### PR TITLE
Fix cuda-on-cl build instructions

### DIFF
--- a/doc/build-from-source.md
+++ b/doc/build-from-source.md
@@ -44,6 +44,9 @@ source ~/env3/bin/activate
 
 # build cuda-on-cl
 pushd third_party/cuda-on-cl
+mkdir build
+cd build
+cmake ..
 make -j 4
 sudo make install
 popd


### PR DESCRIPTION
The current instructions didn't work for me. They failed with an error that no makefile was found.

I've updated the instructions based on those from the `cuda-on-cl repo` (those worked for me)